### PR TITLE
fix: Add an explicit workflow-level permissions block near the top of .github/workflows/nodejs.yml

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -5,6 +5,9 @@ on:
     branches: [develop]
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   build:
     name: Build and Test


### PR DESCRIPTION
Potential fix for [https://github.com/openfoodfacts/openfoodfacts-js/security/code-scanning/42](https://github.com/openfoodfacts/openfoodfacts-js/security/code-scanning/42)

Add an explicit workflow-level `permissions` block near the top of `.github/workflows/nodejs.yml` so all jobs inherit least-privilege defaults.  
Best single fix here: insert

```yml
permissions:
  contents: read
```

directly under the `on:` section (before `jobs:`). This preserves behavior for checkout/build/test workflows and satisfies CodeQL’s recommendation without broadening access. Existing job-level overrides (like `docs`) can remain unchanged.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
