### PR TITLE
fix: permissions for top-issues.yml

### DIFF
--- a/.github/workflows/top-issues.yml
+++ b/.github/workflows/top-issues.yml
@@ -6,6 +6,10 @@ on:
   issues:
     types: [opened, transferred]
 
+permissions:
+  contents: read
+  issues: write
+
 jobs:
   ShowAndLabelTopIssues:
     name: Display and label top issues.


### PR DESCRIPTION
fix: permissions for top-issues.yml
- `contents: read` (safe baseline for repo metadata/content reads)
- `issues: write` (required to add labels/comment/update issues)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated automated workflow permissions to allow reading repository contents and writing issue updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->