### PR TITLE
fix: Add an explicit permissions block in .github/workflows/codeql-analysis.yml

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -7,6 +7,9 @@ on:
   schedule:
     - cron: "0 9 * * 4"
 
+permissions:
+  contents: read
+
 jobs:
   CodeQL-Build:
     runs-on: ubuntu-latest


### PR DESCRIPTION


Add an explicit `permissions` block in `.github/workflows/codeql-analysis.yml` at the workflow root level so it applies to all jobs (including `CodeQL-Build`) unless overridden.  
For this workflow, the minimal safe baseline from the alert is `contents: read`, which preserves functionality for checkout and code scanning while removing implicit broader token access.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated automated security analysis permissions to use read-only repository access.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->