### PR TITLE
fix(KnowledgePanel): add missing icon_url field in KnowledgePanelTableRow type

### DIFF
--- a/src/knowledgepanels.ts
+++ b/src/knowledgepanels.ts
@@ -109,7 +109,11 @@ export type KnowledgePanelElement = KnowledgeElementBase & {
 };
 
 export type KnowledgePanelTableRow = {
-  values: { text: string; evaluation?: string }[];
+	values: {
+    text: string;
+		icon_url?: string;
+		evaluation?: string;
+	}[];
 };
 
 export type KnowledgeTableColumn = {

--- a/src/knowledgepanels.ts
+++ b/src/knowledgepanels.ts
@@ -109,11 +109,11 @@ export type KnowledgePanelElement = KnowledgeElementBase & {
 };
 
 export type KnowledgePanelTableRow = {
-	values: {
+  values: {
     text: string;
-		icon_url?: string;
-		evaluation?: string;
-	}[];
+    icon_url?: string;
+    evaluation?: string;
+  }[];
 };
 
 export type KnowledgeTableColumn = {


### PR DESCRIPTION
### What
Adds an optional `icon_url` field to `KnowledgePanelTableRow['values']`, matching what the API can return for table-type knowledge panels.

```typescript
export type KnowledgePanelTableRow = {
	values: {
		text: string;
		icon_url?: string;
		evaluation?: string;
	}[];
};
```

### Fixes bug(s)
- fixes: #947

### Part of 
- openfoodfacts/openfoodfacts-explorer#1761

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Knowledge panel table values can now include optional icons alongside text and evaluation details.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->