### PR TITLE
fix: temporary workaround for cjs users

### DIFF
--- a/src/facets-kp.ts
+++ b/src/facets-kp.ts
@@ -1,7 +1,11 @@
-import createClient from "openapi-fetch";
+import openapiFetchCreateClient from "openapi-fetch";
+import { unwrapCjsDefault } from "./interop-workaround.js";
 import type { KnowledgePanel } from "./knowledgepanels.js";
 import type { paths } from "./schemas/facets-kp.js";
 import type { FetchFn } from "./types.js";
+
+// https://github.com/rolldown/tsdown/issues/1054
+const createClient = unwrapCjsDefault(openapiFetchCreateClient);
 
 export type FacetKnowledgePanelResponse = {
   knowledge_panels: Record<string, KnowledgePanel>;

--- a/src/folksonomy.ts
+++ b/src/folksonomy.ts
@@ -1,8 +1,12 @@
-import createClient from "openapi-fetch";
+import openapiFetchCreateClient from "openapi-fetch";
+import { unwrapCjsDefault } from "./interop-workaround.js";
 
 import type { paths, components, operations } from "./schemas/folksonomy.js";
 import { DEFAULT_FOLKSONOMY_API_URL, USER_AGENT } from "./consts.js";
 import type { FetchFn } from "./types.js";
+
+// https://github.com/rolldown/tsdown/issues/1054
+const createClient = unwrapCjsDefault(openapiFetchCreateClient);
 
 export type FolksonomyTag = components["schemas"]["ProductTag"];
 export type FolksonomyKey = {

--- a/src/interop-workaround.ts
+++ b/src/interop-workaround.ts
@@ -1,0 +1,6 @@
+// https://github.com/rolldown/tsdown/issues/1054
+export function unwrapCjsDefault<T>(mod: T): T {
+  return typeof mod === "function"
+    ? mod
+    : (mod as unknown as { default: T }).default;
+}

--- a/src/nutripatrol.ts
+++ b/src/nutripatrol.ts
@@ -1,9 +1,13 @@
-import createClient from "openapi-fetch";
+import openapiFetchCreateClient from "openapi-fetch";
+import { unwrapCjsDefault } from "./interop-workaround.js";
 
 import type { components, paths } from "./schemas/nutripatrol.js";
 
 import { DEFAULT_NUTRIPATROL_API_URL, USER_AGENT } from "./consts.js";
 import type { FetchFn } from "./types.js";
+
+// https://github.com/rolldown/tsdown/issues/1054
+const createClient = unwrapCjsDefault(openapiFetchCreateClient);
 
 export type FlagCreate = components["schemas"]["FlagCreate"];
 export type Flag = components["schemas"]["Flag"];

--- a/src/off-v2.ts
+++ b/src/off-v2.ts
@@ -1,4 +1,5 @@
-import createClient from "openapi-fetch";
+import openapiFetchCreateClient from "openapi-fetch";
+import { unwrapCjsDefault } from "./interop-workaround.js";
 import type { components, operations, paths } from "./schemas/server/v2.js";
 import type { TaxoNode } from "./taxonomy/types.js";
 import { formData } from "./openapi.js";
@@ -6,6 +7,9 @@ import { USER_AGENT } from "./consts.js";
 import type { ProductDataType } from "./off-v3.js";
 import type { FetchFn } from "./index.js";
 import { buildNutritionParams } from "./utils.js";
+
+// https://github.com/rolldown/tsdown/issues/1054
+const createClient = unwrapCjsDefault(openapiFetchCreateClient);
 
 export type SearchQuery = operations["get-search"]["parameters"]["query"];
 export type AttributeGroups = components["schemas"]["get_attribute_groups"];

--- a/src/off-v3.ts
+++ b/src/off-v3.ts
@@ -1,4 +1,5 @@
-import createClient from "openapi-fetch";
+import openapiFetchCreateClient from "openapi-fetch";
+import { unwrapCjsDefault } from "./interop-workaround.js";
 import type { components, operations, paths } from "./schemas/server/v3.js";
 import type { KnowledgePanel } from "./knowledgepanels.js";
 import type {
@@ -10,6 +11,9 @@ import type {
   SelectedImage,
   FetchFn,
 } from "./types.js";
+
+// https://github.com/rolldown/tsdown/issues/1054
+const createClient = unwrapCjsDefault(openapiFetchCreateClient);
 
 export type ResponseStatus = components["schemas"]["response_status"];
 export type Product = components["schemas"]["product_v3"];

--- a/src/prices.ts
+++ b/src/prices.ts
@@ -1,8 +1,12 @@
-import createClient from "openapi-fetch";
+import openapiFetchCreateClient from "openapi-fetch";
+import { unwrapCjsDefault } from "./interop-workaround.js";
 import type { components, paths } from "./schemas/prices.js";
 import { USER_AGENT } from "./consts.js";
 import type { UnwrapContent } from "./openapi.js";
 import type { FetchFn } from "./types.js";
+
+// https://github.com/rolldown/tsdown/issues/1054
+const createClient = unwrapCjsDefault(openapiFetchCreateClient);
 
 type GetPricesQuery = paths["/api/v1/prices"]["get"]["parameters"]["query"];
 

--- a/src/robotoff.ts
+++ b/src/robotoff.ts
@@ -1,9 +1,13 @@
-import createClient from "openapi-fetch";
+import openapiFetchCreateClient from "openapi-fetch";
+import { unwrapCjsDefault } from "./interop-workaround.js";
 
 import type { operations, paths } from "./schemas/robotoff.js";
 import { DEFAULT_ROBOTOFF_API_URL, USER_AGENT } from "./consts.js";
 import { formBody } from "./formbody.js";
 import type { FetchFn } from "./types.js";
+
+// https://github.com/rolldown/tsdown/issues/1054
+const createClient = unwrapCjsDefault(openapiFetchCreateClient);
 
 export type RobotoffInsightQuery =
   paths["/insights"]["get"]["parameters"]["query"];

--- a/src/search.ts
+++ b/src/search.ts
@@ -1,7 +1,11 @@
 import type { paths } from "./schemas/search.js";
-import createClient from "openapi-fetch";
+import openapiFetchCreateClient from "openapi-fetch";
+import { unwrapCjsDefault } from "./interop-workaround.js";
 import { USER_AGENT } from "./consts.js";
 import type { FetchFn } from "./types.js";
+
+// https://github.com/rolldown/tsdown/issues/1054
+const createClient = unwrapCjsDefault(openapiFetchCreateClient);
 
 const SEARCH_BASE_URL = "https://search.openfoodfacts.org";
 


### PR DESCRIPTION
### What
Introduces a small workaround shim for broken CJS runtimes caused by tsdown. Not the fault of this package but I thought I'd submit upstream for any other CJS-style runtime users.

### Fixes bug(s)
rolldown/tsdown#953

### Part of
https://github.com/rolldown/rolldown/issues/10800

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved compatibility when loading API clients across CommonJS and ES module environments.
  - Prevented potential bundling and runtime issues affecting API-backed features, including search, pricing, nutrition, and other data services.
  - Improved reliability across supported build environments without requiring changes to existing integrations.
  - Preserved existing public APIs and behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->